### PR TITLE
Fix iss22

### DIFF
--- a/teams/graphs.py
+++ b/teams/graphs.py
@@ -10,16 +10,6 @@ from bokeh.models.widgets import Select
 
 from teams.models import Event, EVENT_CHOICE, Swimmer
 
-class DatetimeEncoder(json.JSONEncoder):
-    """
-    Encodes Python datetime.date objects to make compatible with JSON serialization.
-    """
-    def default(self, obj):
-        try:
-            return super(DatetimeEncoder, obj).default(obj)
-        except TypeError:
-            return str(obj)
-
 def date_time_hover_tool():
     """
     Generates the HTML for the Bokeh's hover data tool on our graph.


### PR DESCRIPTION
Progress tracking charts are now scaling and updating correctly. There needs to be at least two event objects of a particular event for it to show up in the chart.


<img width="634" alt="screenshot 2017-10-28 18 14 08" src="https://user-images.githubusercontent.com/13025203/32138993-d51f4bbe-bc0b-11e7-864f-f3fa3dd1bcd4.png">
<img width="633" alt="screenshot 2017-10-28 18 14 19" src="https://user-images.githubusercontent.com/13025203/32138994-d53357ee-bc0b-11e7-8cdc-2f79fbbaf34a.png">

